### PR TITLE
Fixed implicit conversion from Blink1Duration to TimeSpan

### DIFF
--- a/src/Sleddog.Blink1.Tests/Blink1DurationTests.cs
+++ b/src/Sleddog.Blink1.Tests/Blink1DurationTests.cs
@@ -11,7 +11,7 @@ namespace Sleddog.Blink1.Tests
 		private static readonly Random rnd = new Random();
 
 		[Theory, PropertyData("HighTestData")]
-		public void HighIsSetCorrectlyFromTimeSpanCtorInput(double timeInMilliseconds, byte expected)
+		public void HighIsSetCorrectlyFromTimeSpanCtorInput(int timeInMilliseconds, byte expected)
 		{
 			var ts = TimeSpan.FromMilliseconds(timeInMilliseconds);
 
@@ -23,7 +23,7 @@ namespace Sleddog.Blink1.Tests
 		}
 
 		[Theory, PropertyData("LowTestData")]
-		public void LowIsSetCorrectlyFromTimeSpanCtorInput(double timeInMilliseconds, byte expected)
+		public void LowIsSetCorrectlyFromTimeSpanCtorInput(int timeInMilliseconds, byte expected)
 		{
 			var ts = TimeSpan.FromMilliseconds(timeInMilliseconds);
 
@@ -34,6 +34,18 @@ namespace Sleddog.Blink1.Tests
 			Assert.Equal(expected, actual);
 		}
 
+		[Theory, PropertyData("ImplicitTestData")]
+		public void ImplicitConversionToTimeSpan(int timeInMilliseconds, double expected)
+		{
+			var ts = TimeSpan.FromMilliseconds(timeInMilliseconds);
+
+			var sut = new Blink1Duration(ts);
+
+			TimeSpan actual = sut;
+
+			Assert.Equal(expected, actual.TotalMilliseconds);
+		}
+
 		public static IEnumerable<object[]> HighTestData
 		{
 			get
@@ -42,7 +54,7 @@ namespace Sleddog.Blink1.Tests
 
 				foreach (var val in GenerateSampleData())
 				{
-					var expected = Convert.ToByte((val/10) >> 8);
+					var expected = Convert.ToByte(Convert.ToInt32(val/Blink1Duration.Blink1UpdateFrequency) >> 8);
 
 					yield return new object[] {val, expected};
 				}
@@ -57,12 +69,32 @@ namespace Sleddog.Blink1.Tests
 
 				foreach (var val in GenerateSampleData())
 				{
-					var expected = Convert.ToByte((val/10) & 0xFF);
+					var expected = Convert.ToByte(Convert.ToInt32(val/Blink1Duration.Blink1UpdateFrequency) & 0xFF);
 
 					yield return new object[] {val, expected};
 				}
 			}
 		}
+
+		public static IEnumerable<object[]> ImplicitTestData
+		{
+			get
+			{
+				yield return new object[] { 0, 0d };
+				yield return new object[] { 250, 250d };
+				yield return new object[] { 254, 250d };
+				yield return new object[] { 255, 260d };
+				yield return new object[] { 256, 260d };
+
+				foreach (var val in GenerateSampleData())
+				{
+					double expected = Convert.ToInt32(val / Blink1Duration.Blink1UpdateFrequency) * Blink1Duration.Blink1UpdateFrequency;
+
+					yield return new object[] { val, expected };
+				}
+			}
+		}
+
 
 		private static IEnumerable<int> GenerateSampleData()
 		{

--- a/src/Sleddog.Blink1/Blink1Duration.cs
+++ b/src/Sleddog.Blink1/Blink1Duration.cs
@@ -4,16 +4,14 @@ namespace Sleddog.Blink1
 {
 	internal class Blink1Duration
 	{
-		private const int Blink1UpdateFrequency = 10;
+		public const double Blink1UpdateFrequency = 10d;
 
 		public byte High { get; private set; }
 		public byte Low { get; private set; }
 
 		public Blink1Duration(TimeSpan duration)
 		{
-			var durationInMilliseconds = Convert.ToInt32(duration.TotalMilliseconds);
-
-			var blinkTime = (durationInMilliseconds/Blink1UpdateFrequency);
+			var blinkTime = Convert.ToInt32(duration.TotalMilliseconds/Blink1UpdateFrequency);
 
 			High = Convert.ToByte(blinkTime >> 8);
 			Low = Convert.ToByte(blinkTime & 0xFF);
@@ -58,7 +56,7 @@ namespace Sleddog.Blink1
 			var low = duration.Low;
 			var high = duration.High;
 
-			var blinkTime = Convert.ToInt32(high | low << 8);
+			var blinkTime = Convert.ToInt32((high << 8) | low);
 
 			return TimeSpan.FromMilliseconds(blinkTime*Blink1UpdateFrequency);
 		}


### PR DESCRIPTION
Implicit conversion from Blink1Duration to TimeSpan was not being calculated correctly.

I also updated the code so that the conversion will round to the nearest Blink1 update interval instead of always truncating the remainder. See ImplicitConversionToTimeSpan test.

For example:

253ms  = `Convert.ToInt32(253 / 10.d) == 25`
255ms  = `Convert.ToInt32(255 / 10.d) == 26`
